### PR TITLE
Multiple intent services containers

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -281,11 +281,15 @@ class RecognizerLoop(EventEmitter):
                   operational status.
     """
 
-    def __init__(self, watchdog=None):
+    def __init__(self, watchdog=None, stt=None):
         super(RecognizerLoop, self).__init__()
         self._watchdog = watchdog
         self.mute_calls = 0
         self._load_config()
+        self._stt = stt
+
+    def bind(self, stt):
+        self._stt = stt
 
     def _load_config(self):
         """Load configuration parameters from configuration."""
@@ -369,7 +373,10 @@ class RecognizerLoop(EventEmitter):
     def start_async(self):
         """Start consumer and producer threads."""
         self.state.running = True
-        stt = STTFactory.create()
+        if self._stt:
+            stt = self._stt
+        else:
+            stt = STTFactory.create()
         queue = Queue()
         stream_handler = None
         if stt.can_stream:

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -370,6 +370,7 @@ class IntentService:
                     if match:
                         break
             if match:
+                print(match)
                 if match.skill_id:
                     self.add_active_skill(match.skill_id)
                     # If the service didn't report back the skill_id it
@@ -438,8 +439,9 @@ class IntentService:
         end_concept = message.data.get('end')
         regex_str = message.data.get('regex')
         alias_of = message.data.get('alias_of')
+        lang = message.data.get('lang')
         self.adapt_service.register_vocab(start_concept, end_concept,
-                                          alias_of, regex_str)
+                                          alias_of, regex_str, lang)
         self.registered_vocab.append(message.data)
 
     def handle_register_intent(self, message):

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -370,7 +370,6 @@ class IntentService:
                     if match:
                         break
             if match:
-                print(match)
                 if match.skill_id:
                     self.add_active_skill(match.skill_id)
                     # If the service didn't report back the skill_id it

--- a/mycroft/skills/intent_service_interface.py
+++ b/mycroft/skills/intent_service_interface.py
@@ -44,7 +44,8 @@ class IntentServiceInterface:
     def set_id(self, skill_id):
         self.skill_id = skill_id
 
-    def register_adapt_keyword(self, vocab_type, entity, aliases=None):
+    def register_adapt_keyword(
+            self, vocab_type, entity, aliases=None, lang=None):
         """Send a message to the intent service to add an Adapt keyword.
 
             vocab_type(str): Keyword reference
@@ -56,12 +57,17 @@ class IntentServiceInterface:
         if "skill_id" not in msg.context:
             msg.context["skill_id"] = self.skill_id
         self.bus.emit(msg.forward("register_vocab",
-                              {'start': entity, 'end': vocab_type}))
+                                  {'start': entity,
+                                   'end': vocab_type,
+                                   'lang': lang}))
         for alias in aliases:
             self.bus.emit(msg.forward("register_vocab", {
-                'start': alias, 'end': vocab_type, 'alias_of': entity}))
+                'start': alias,
+                'end': vocab_type,
+                'alias_of': entity,
+                'lang': lang}))
 
-    def register_adapt_regex(self, regex):
+    def register_adapt_regex(self, regex, lang=None):
         """Register a regex with the intent service.
 
         Args:
@@ -71,7 +77,8 @@ class IntentServiceInterface:
         msg = dig_for_message() or Message("")
         if "skill_id" not in msg.context:
             msg.context["skill_id"] = self.skill_id
-        self.bus.emit(msg.forward("register_vocab", {'regex': regex}))
+        self.bus.emit(msg.forward("register_vocab", {
+            'regex': regex, 'lang': lang}))
 
     def register_adapt_intent(self, name, intent_parser):
         """Register an Adapt intent parser object.
@@ -82,7 +89,8 @@ class IntentServiceInterface:
         msg = dig_for_message() or Message("")
         if "skill_id" not in msg.context:
             msg.context["skill_id"] = self.skill_id
-        self.bus.emit(msg.forward("register_intent", intent_parser.__dict__))
+        data = intent_parser.__dict__
+        self.bus.emit(msg.forward("register_intent", data))
         self.registered_intents.append((name, intent_parser))
         self.detached_intents = [detached for detached in self.detached_intents
                                  if detached[0] != name]
@@ -133,7 +141,7 @@ class IntentServiceInterface:
             msg.context["skill_id"] = self.skill_id
         self.bus.emit(msg.forward('remove_context', {'context': context}))
 
-    def register_padatious_intent(self, intent_name, filename):
+    def register_padatious_intent(self, intent_name, filename, lang):
         """Register a padatious intent file with Padatious.
 
         Args:
@@ -145,15 +153,16 @@ class IntentServiceInterface:
         if not exists(filename):
             raise FileNotFoundError('Unable to find "{}"'.format(filename))
 
-        data = {"file_name": filename,
-                "name": intent_name}
+        data = {'file_name': filename,
+                'name': intent_name,
+                'lang': lang}
         msg = dig_for_message() or Message("")
-        if "skill_id" not in msg.context:
-            msg.context["skill_id"] = self.skill_id
-        self.bus.emit(msg.forward("padatious:register_intent", data))
+        if 'skill_id' not in msg.context:
+            msg.context['skill_id'] = self.skill_id
+        self.bus.emit(msg.forward('padatious:register_intent', data))
         self.registered_intents.append((intent_name.split(':')[-1], data))
 
-    def register_padatious_entity(self, entity_name, filename):
+    def register_padatious_entity(self, entity_name, filename, lang):
         """Register a padatious entity file with Padatious.
 
         Args:
@@ -167,9 +176,11 @@ class IntentServiceInterface:
         msg = dig_for_message() or Message("")
         if "skill_id" not in msg.context:
             msg.context["skill_id"] = self.skill_id
-        self.bus.emit(msg.forward('padatious:register_entity',
-                              {'file_name': filename,
-                               'name': entity_name}))
+        self.bus.emit(msg.forward(
+            'padatious:register_entity',
+            {'file_name': filename,
+             'name': entity_name,
+             'lang': lang}))
 
     def __iter__(self):
         """Iterator over the registered intents.

--- a/mycroft/skills/intent_services/padatious_service.py
+++ b/mycroft/skills/intent_services/padatious_service.py
@@ -18,6 +18,7 @@ from subprocess import call
 from threading import Event
 from time import time as get_time, sleep
 
+from os import path
 from os.path import expanduser, isfile
 
 from mycroft.configuration import Configuration
@@ -36,10 +37,17 @@ class PadatiousService:
         intent_cache = expanduser(self.padatious_config['intent_cache'])
         self._padaos = self.padatious_config.get("padaos_only", False)
 
+        self.lang = Configuration.get().get("lang", "en-us")
+        self.langs = Configuration.get().get('secondary_langs', [])
+        if self.lang not in self.langs:
+            self.langs.append(self.lang)
+
         try:
             if not self._padaos:
                 from padatious import IntentContainer
-                self.container = IntentContainer(intent_cache)
+                self.containers = {
+                    lang: IntentContainer(path.join(intent_cache, lang))
+                    for lang in self.langs}
         except ImportError:
             LOG.error('Padatious not installed. Falling back to Padaos, pure regex alternative')
             try:
@@ -52,7 +60,8 @@ class PadatiousService:
         if self._padaos:
             LOG.warning('using padaos instead of padatious. Some intents may '
                         'be hard to trigger')
-            self.container = PadaosIntentContainer()
+            self.containers = {lang: PadaosIntentContainer()
+                               for lang in self.langs}
 
         self.bus.on('padatious:register_intent', self.register_intent)
         self.bus.on('padatious:register_entity', self.register_entity)
@@ -85,7 +94,8 @@ class PadatiousService:
                 single_thread = message.data.get('single_thread',
                                                  padatious_single_thread)
             LOG.info('Training... (single_thread={})'.format(single_thread))
-            self.container.train(single_thread=single_thread)
+            for lang in self.langs:
+                self.containers.get(lang).train(single_thread=single_thread)
             LOG.info('Training complete.')
 
         self.finished_training_event.set()
@@ -113,7 +123,8 @@ class PadatiousService:
         """
         if intent_name in self.registered_intents:
             self.registered_intents.remove(intent_name)
-            self.container.remove_intent(intent_name)
+            for lang in self.langs:
+                self.containers.get(lang).remove_intent(intent_name)
 
     def handle_detach_intent(self, message):
         """Messagebus handler for detaching padatious intent.
@@ -167,11 +178,15 @@ class PadatiousService:
         Args:
             message (Message): message triggering action
         """
-        self.registered_intents.append(message.data['name'])
-        if self._padaos:
-            self._register_object(message, 'intent', self.container.add_intent)
-        else:
-            self._register_object(message, 'intent', self.container.load_intent)
+        lang = message.data.get('lang', self.lang)
+        if lang in self.langs:
+            self.registered_intents.append(message.data['name'])
+            if self._padaos:
+                self._register_object(
+                    message, 'intent', self.containers.get(lang).add_intent)
+            else:
+                self._register_object(
+                    message, 'intent', self.containers.get(lang).load_intent)
 
     def register_entity(self, message):
         """Messagebus handler for registering entities.
@@ -179,13 +194,17 @@ class PadatiousService:
         Args:
             message (Message): message triggering action
         """
-        self.registered_entities.append(message.data)
-        if self._padaos:
-            self._register_object(message, 'intent', self.container.add_entity)
-        else:
-            self._register_object(message, 'entity', self.container.load_entity)
+        lang = message.data.get('lang', self.lang)
+        if lang in self.langs:
+            self.registered_entities.append(message.data)
+            if self._padaos:
+                self._register_object(
+                    message, 'intent', self.containers.get(lang).add_entity)
+            else:
+                self._register_object(
+                    message, 'entity', self.containers.get(lang).load_entity)
 
-    def _match_level(self, utterances, limit):
+    def _match_level(self, utterances, limit, lang=None):
         """Match intent and make sure a certain level of confidence is reached.
 
         Args:
@@ -193,11 +212,12 @@ class PadatiousService:
                                          with optional normalized version.
             limit (float): required confidence level.
         """
+        lang = lang or self.lang
         padatious_intent = None
         LOG.debug('Padatious Matching confidence > {}'.format(limit))
         for utt in utterances:
             for variant in utt:
-                intent = self.calc_intent(variant)
+                intent = self.calc_intent(variant, lang)
                 if self._padaos:
                     if not intent.get("name"):
                         continue
@@ -225,35 +245,35 @@ class PadatiousService:
             ret = None
         return ret
 
-    def match_high(self, utterances, _=None, __=None):
+    def match_high(self, utterances, lang=None, __=None):
         """Intent matcher for high confidence.
 
         Args:
             utterances (list of tuples): Utterances to parse, originals paired
                                          with optional normalized version.
         """
-        return self._match_level(utterances, 0.95)
+        return self._match_level(utterances, 0.95, lang)
 
-    def match_medium(self, utterances, _=None, __=None):
+    def match_medium(self, utterances, lang=None, __=None):
         """Intent matcher for medium confidence.
 
         Args:
             utterances (list of tuples): Utterances to parse, originals paired
                                          with optional normalized version.
         """
-        return self._match_level(utterances, 0.8)
+        return self._match_level(utterances, 0.8, lang)
 
-    def match_low(self, utterances, _=None, __=None):
+    def match_low(self, utterances, lang=None, __=None):
         """Intent matcher for low confidence.
 
         Args:
             utterances (list of tuples): Utterances to parse, originals paired
                                          with optional normalized version.
         """
-        return self._match_level(utterances, 0.5)
+        return self._match_level(utterances, 0.5, lang)
 
     @lru_cache(maxsize=2)  # 2 catches both raw and normalized utts in cache
-    def calc_intent(self, utt):
+    def calc_intent(self, utt, lang=None):
         """Cached version of container calc_intent.
 
         This improves speed when called multiple times for different confidence
@@ -266,4 +286,6 @@ class PadatiousService:
         Args:
             utt (str): utterance to calculate best intent for
         """
-        return self.container.calc_intent(utt)
+        lang = lang or self.lang
+        if lang in self.langs:
+            return self.containers.get(lang).calc_intent(utt)

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -1310,7 +1310,7 @@ class MycroftSkill:
         re.compile(regex)  # validate regex
         self.intent_service.register_adapt_regex(regex)
 
-    def speak(self, utterance, expect_response=False, wait=False, meta=None):
+    def speak(self, utterance, expect_response=False, wait=True, meta=None):
         """Speak a sentence.
 
         Args:
@@ -1339,7 +1339,7 @@ class MycroftSkill:
         if wait:
             wait_while_speaking()
 
-    def speak_dialog(self, key, data=None, expect_response=False, wait=False):
+    def speak_dialog(self, key, data=None, expect_response=False, wait=True):
         """ Speak a random sentence from a dialog file.
 
         Args:

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -874,13 +874,12 @@ class MycroftSkill:
         """
         lang = lang or self.lang
         result = self._find_resource(res_name, lang, res_dirname)
-        if not result and lang != 'en-us':
+        if not result:
             # when resource not found try fallback to en-us
             LOG.warning(
-                "Resource '{}' for lang '{}' not found: trying 'en-us'"
+                "Resource '{}' for lang '{}' not found"
                 .format(res_name, lang)
             )
-            result = self._find_resource(res_name, 'en-us', res_dirname)
         return result
 
     def _find_resource(self, res_name, lang, res_dirname=None):

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -246,8 +246,12 @@ class MycroftSkill:
 
     @property
     def lang(self):
-        """Get the configured language."""
-        return self.config_core.get('lang')
+        """Get the current language."""
+        message = dig_for_message()
+        core_lang = Configuration.get().get("lang", "en-us")
+        if message:
+            return message.data.get("lang") or core_lang
+        return core_lang
 
     @property
     def secondary_langs(self):
@@ -264,7 +268,7 @@ class MycroftSkill:
         """
         # NOTE this should not be private, but for backwards compat with
         # mycroft-core it is, dont want skills to call it directly
-        lang = lang or self._dig_for_lang()
+        lang = lang or self.lang
         lang_path = join(base_path, lang)
 
         # base_path/en-us
@@ -488,12 +492,6 @@ class MycroftSkill:
         self.converse = default_converse
         return converse.response
 
-    def _dig_for_lang(self):
-        message = dig_for_message()
-        if message:
-            return message.data.get("lang") or self.lang
-        return self.lang
-
     def get_response(self, dialog='', data=None, validator=None,
                      on_fail=None, num_retries=-1):
         """Get response from user.
@@ -531,9 +529,7 @@ class MycroftSkill:
         """
         data = data or {}
 
-        lang = self._dig_for_lang()
-        renderer = self.dialog_renderers.get(lang) or \
-                   self.dialog_renderers.get(self.lang)
+        renderer = self.dialog_renderers.get(self.lang)
 
         def on_fail_default(utterance):
             fail_data = data.copy()
@@ -841,9 +837,7 @@ class MycroftSkill:
         Returns:
             str: A randomly chosen string from the file
         """
-        lang = self._dig_for_lang()
-        renderer = self.dialog_renderers.get(lang) or \
-                   self.dialog_renderers.get(self.lang)
+        renderer = self.dialog_renderers.get(self.lang)
         if not renderer:
             return ""
         return renderer.render(text, data or {})
@@ -878,7 +872,7 @@ class MycroftSkill:
         Returns:
             string: The full path to the resource file or None if not found
         """
-        lang = lang or self._dig_for_lang()
+        lang = lang or self.lang
         result = self._find_resource(res_name, lang, res_dirname)
         if not result and lang != 'en-us':
             # when resource not found try fallback to en-us
@@ -1333,7 +1327,7 @@ class MycroftSkill:
         m = message.forward("speak", data) if message \
             else Message("speak", data)
         m.context["skill_id"] = self.skill_id
-        m.data["lang"] = self._dig_for_lang()
+        m.data["lang"] = self.lang
         self.bus.emit(m)
 
         if wait:
@@ -1352,9 +1346,7 @@ class MycroftSkill:
             wait (bool):            set to True to block while the text
                                     is being spoken.
         """
-        lang = self._dig_for_lang()
-        renderer = self.dialog_renderers.get(lang) or \
-                   self.dialog_renderers.get(self.lang)
+        renderer = self.dialog_renderers.get(self.lang)
         if renderer:
             data = data or {}
             self.speak(

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -170,6 +170,16 @@ class MycroftSkill:
     def dialog_renderer(self):
         if self.lang in self.langs:
             return self.dialog_renderers.get(self.lang)
+        # Try to load the dialect renderer
+        root_directory = self.root_dir
+        dialog_dir = self._get_language_dir(
+            join(root_directory, 'dialog'), self.lang)
+        if exists(dialog_dir):
+            return load_dialogs(dialog_dir)
+        locale_dir = self._get_language_dir(
+            join(root_directory, 'locale'), self.lang)
+        if exists(locale_dir):
+            return load_dialogs(locale_dir)
         # Use different dialect
         lang2 = self.lang.split('-')[0]
         for lang in self.langs:

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -258,8 +258,8 @@ class MycroftSkill:
         """Get the configured secondary languages, mycroft is not
         considered to be in these languages but i will load it's resource
         files. This provides initial support for multilingual input"""
-        return [l for l in self.config_core.get('secondary_langs', [])
-                if l != self.lang]
+        return [lang for lang in self.config_core.get('secondary_langs', [])
+                if lang != self.lang]
 
     def _get_language_dir(self, base_path, lang=None):
         """ checks for all language variations and returns best path
@@ -529,7 +529,7 @@ class MycroftSkill:
         """
         data = data or {}
 
-        renderer = self.dialog_renderers.get(self.lang)
+        renderer = self.dialog_renderer
 
         def on_fail_default(utterance):
             fail_data = data.copy()
@@ -700,7 +700,7 @@ class MycroftSkill:
             utt (str): Utterance to be tested
             voc_filename (str): Name of vocabulary file (e.g. 'yes' for
                                 'res/text/en-us/yes.voc')
-            lang (str): Language code, defaults to self.long
+            lang (str): Language code, defaults to self.lang
             exact (bool): Whether the vocab must exactly match the utterance
 
         Returns:
@@ -837,7 +837,7 @@ class MycroftSkill:
         Returns:
             str: A randomly chosen string from the file
         """
-        renderer = self.dialog_renderers.get(self.lang)
+        renderer = self.dialog_renderer
         if not renderer:
             return ""
         return renderer.render(text, data or {})
@@ -1346,7 +1346,7 @@ class MycroftSkill:
             wait (bool):            set to True to block while the text
                                     is being spoken.
         """
-        renderer = self.dialog_renderers.get(self.lang)
+        renderer = self.dialog_renderer
         if renderer:
             data = data or {}
             self.speak(
@@ -1380,10 +1380,10 @@ class MycroftSkill:
     def _load_dialog_files(self, root_directory, lang):
         # If "<skill>/dialog/<lang>" exists, load from there.  Otherwise
         # load dialog from "<skill>/locale/<lang>"
-        dialog_dir = self._get_language_dir(join(root_directory, 'dialog'),
-                                           lang)
-        locale_dir = self._get_language_dir(join(root_directory, 'locale'),
-                                            lang)
+        dialog_dir = self._get_language_dir(
+            join(root_directory, 'dialog'), lang)
+        locale_dir = self._get_language_dir(
+            join(root_directory, 'locale'), lang)
         if exists(dialog_dir):
             self.dialog_renderers[lang] = load_dialogs(dialog_dir)
         elif exists(locale_dir):

--- a/mycroft/skills/skill_data.py
+++ b/mycroft/skills/skill_data.py
@@ -65,8 +65,12 @@ def load_regex_from_file(path, skill_id):
                 regex = munge_regex(line.strip(), skill_id)
                 LOG.debug('regex post-munge: ' + regex)
                 # Raise error if regex can't be compiled
-                re.compile(regex)
-                regexes.append(regex)
+                try:
+                    re.compile(regex)
+                    regexes.append(regex)
+                except Exception as e:
+                    LOG.warning('Failed to compile regex {}: {}'.format(
+                        regex, e))
 
     return regexes
 

--- a/mycroft/version/__init__.py
+++ b/mycroft/version/__init__.py
@@ -26,7 +26,7 @@ from mycroft.util.log import LOG
 CORE_VERSION_MAJOR = 21
 CORE_VERSION_MINOR = 2
 CORE_VERSION_BUILD = 1
-RELEASE_DATE = 20210908  # YYYYMMDD date of sync with mycroft-core
+RELEASE_DATE = 20210909  # YYYYMMDD date of sync with mycroft-core
 
 # END_VERSION_BLOCK
 


### PR DESCRIPTION
Adapt and Padacious intent services now have different engines/containers to match skills for the specific language of the message.
The supported languages are defined by the already defined config parameters "lang" and "secondary_langs".
If the language of the message is not supported a different language dialect will be used instead.
If no dialect of the language is supported the intent service will speak in english "Language not supported".