### PR TITLE
Add Build Tests

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Install Build Tools
         run: |
           python -m pip install build wheel
+      - name: Install System Dependencies
+        run: |
+          sudo apt install python3-dev swig libssl-dev libfann-dev portaudio19-dev
       - name: Build Distribution Packages
         run: |
           python setup.py bdist_wheel

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -1,0 +1,25 @@
+name: Run Build Tests
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install Build Tools
+        run: |
+          python -m pip install build wheel
+      - name: Build Distribution Packages
+        run: |
+          python setup.py bdist_wheel
+      - name: Install HolmesV package
+        run: |
+          pip install .[audio-backend,mark1,stt,tts,skills_minimal,skills,default_skills,enclosure,bus,all]

--- a/requirements/extra-mycroft.txt
+++ b/requirements/extra-mycroft.txt
@@ -1,3 +1,4 @@
+# This dependency list has been deprecated!
 requests>=2.20.0
 gTTS>=2.2.2
 PyAudio==0.2.11

--- a/requirements/minimal.txt
+++ b/requirements/minimal.txt
@@ -2,7 +2,7 @@ requests>=2.20.0
 pyee==8.1.0
 mock_msm>=0.9.2
 pyxdg>=0.26
-mycroft-messagebus-client>=0.9.4
+mycroft-messagebus-client>=0.9.1,!=0.9.2,!=0.9.3
 inflection>=0.3.1
 psutil>=5.6.6
 fasteners>=0.14.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -17,7 +17,7 @@ PyYAML==5.4
 
 lingua-nostra>=0.4.4
 mock_msm>=0.9.2
-mycroft-messagebus-client>=0.9.4
+mycroft-messagebus-client>=0.9.1,!=0.9.2,!=0.9.3
 adapt-parser==0.5.1
 padatious==0.4.8
 fann2==1.0.7


### PR DESCRIPTION
Adds automated testing of setup.py builds and pip installation with all valid extras to check for any dependency conflicts
Modifies requirements to include mycroft-messagebus-client==0.9.1 which should still be compatible